### PR TITLE
Add Apps Script backend and basic frontend

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,104 @@
+const CONFIG_SHEET_NAME = 'Data';
+
+/**
+ * Returns master KPI configuration from the Data sheet.
+ * @returns {Object} API response containing configuration list
+ */
+function getKPIConfiguration() {
+  const sheet = SpreadsheetApp.getActive().getSheetByName(CONFIG_SHEET_NAME);
+  if (!sheet) {
+    return buildError('Configuration sheet not found');
+  }
+  const data = sheet.getDataRange().getValues();
+  const headers = data.shift();
+  const configuration = data.map(row => {
+    const obj = {};
+    headers.forEach((h, i) => (obj[h] = row[i]));
+    return obj;
+  });
+  return buildResponse({ configuration });
+}
+
+/**
+ * Returns raw data from a given source sheet name.
+ * @param {String} sheetName The name of the source sheet
+ * @returns {Object} API response containing sheet data
+ */
+function getSourceSheetData(sheetName) {
+  const ss = SpreadsheetApp.getActive();
+  const sheet = ss.getSheetByName(sheetName);
+  if (!sheet) {
+    return buildError('Source sheet not found: ' + sheetName);
+  }
+  const data = sheet.getDataRange().getValues();
+  const headers = data.shift();
+  const rows = data.map(r => {
+    const obj = {};
+    headers.forEach((h, i) => (obj[h] = r[i]));
+    return obj;
+  });
+  return buildResponse(rows);
+}
+
+/**
+ * Returns all KPI configuration and related source data.
+ * @returns {Object} API response containing configuration and source data
+ */
+function getAllKPIData() {
+  const confResp = getKPIConfiguration();
+  if (confResp.status === 'error') {
+    return confResp;
+  }
+  const configuration = confResp.data.configuration;
+  const sourceData = {};
+  const groups = new Set();
+  configuration.forEach(item => {
+    const sheetName = item['sheet_source'];
+    groups.add(item['ประเด็นขับเคลื่อน']);
+    if (sheetName && !sourceData[sheetName]) {
+      const resp = getSourceSheetData(sheetName);
+      sourceData[sheetName] = resp.data;
+    }
+  });
+  return buildResponse({
+    configuration,
+    sourceData,
+    groups: Array.from(groups)
+  });
+}
+
+/**
+ * Returns KPI data filtered by driving issue (group name).
+ * @param {String} groupName The driving issue to filter by
+ * @returns {Object} API response containing filtered configuration
+ */
+function getKPIByGroup(groupName) {
+  const confResp = getKPIConfiguration();
+  if (confResp.status === 'error') {
+    return confResp;
+  }
+  const configuration = confResp.data.configuration.filter(item => item['ประเด็นขับเคลื่อน'] === groupName);
+  return buildResponse({ configuration });
+}
+
+/**
+ * Helper to build consistent API response.
+ */
+function buildResponse(data) {
+  return {
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    data
+  };
+}
+
+/**
+ * Helper to build error responses.
+ */
+function buildError(message) {
+  return {
+    status: 'error',
+    timestamp: new Date().toISOString(),
+    message
+  };
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+  <header class="p-4 bg-blue-600 text-white flex justify-between">
+    <h1 class="text-xl font-semibold">KPI Dashboard</h1>
+    <div id="last-updated" class="text-sm"></div>
+  </header>
+
+  <main class="p-4 space-y-4">
+    <!-- Filter Panel -->
+    <section class="bg-white p-4 rounded shadow">
+      <div class="flex flex-wrap gap-4" id="filters"></div>
+      <button id="resetFilters" class="mt-4 px-4 py-2 bg-gray-200 rounded">Reset Filter</button>
+    </section>
+
+    <!-- KPI Group Cards -->
+    <section id="groupCards" class="grid md:grid-cols-3 gap-4"></section>
+
+    <!-- KPI Detail Table -->
+    <section class="bg-white p-4 rounded shadow">
+      <table class="min-w-full table-auto" id="detailTable">
+        <thead>
+          <tr class="bg-gray-200">
+            <th class="p-2">ตัวชี้วัดย่อย</th>
+            <th class="p-2">หน่วยบริการ</th>
+            <th class="p-2">เป้าหมาย</th>
+            <th class="p-2">ผลงาน</th>
+            <th class="p-2">ร้อยละ</th>
+            <th class="p-2">เกณฑ์ผ่าน</th>
+            <th class="p-2">วันที่อัพเดท</th>
+          </tr>
+        </thead>
+        <tbody id="tableBody"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <!-- Modal -->
+  <div id="modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white p-4 rounded shadow max-h-full overflow-auto w-11/12 md:w-2/3">
+      <button id="closeModal" class="float-right text-red-500">X</button>
+      <pre id="modalContent" class="mt-4 whitespace-pre-wrap"></pre>
+    </div>
+  </div>
+
+  <script>
+    const API_BASE = 'https://script.google.com/macros/s/AKfycbwTCVRGkFte39699yAHm5d1suYsU9RUFM8mjtoohhj5uBWfHKsRkSI3MVbRJyw4oU_YKQ/exec';
+    let allData = null;
+
+    async function fetchAll() {
+      const res = await fetch(`${API_BASE}?action=getAllKPIData`);
+      const json = await res.json();
+      if (json.status !== 'success') {
+        console.error(json.message);
+        return;
+      }
+      allData = json.data;
+      document.getElementById('last-updated').textContent = new Date(json.timestamp).toLocaleString();
+      renderFilters();
+      renderGroupCards();
+      renderTable(allData.configuration);
+    }
+
+    function renderFilters() {
+      const filterContainer = document.getElementById('filters');
+      filterContainer.innerHTML = '';
+      const groups = allData.groups;
+      const select = document.createElement('select');
+      select.id = 'groupFilter';
+      select.className = 'p-2 border rounded';
+      select.innerHTML = `<option value="">เลือกประเด็นขับเคลื่อน</option>`;
+      groups.forEach(g => {
+        const opt = document.createElement('option');
+        opt.value = g;
+        opt.textContent = g;
+        select.appendChild(opt);
+      });
+      select.addEventListener('change', () => {
+        const value = select.value;
+        if (value) {
+          renderTable(allData.configuration.filter(c => c['ประเด็นขับเคลื่อน'] === value));
+        } else {
+          renderTable(allData.configuration);
+        }
+      });
+      filterContainer.appendChild(select);
+      document.getElementById('resetFilters').onclick = () => { select.value = ''; renderTable(allData.configuration); };
+    }
+
+    function renderGroupCards() {
+      const container = document.getElementById('groupCards');
+      container.innerHTML = '';
+      const grouped = {};
+      allData.configuration.forEach(item => {
+        const key = item['ประเด็นขับเคลื่อน'];
+        if (!grouped[key]) grouped[key] = { count: 0, percent: 0 };
+        grouped[key].count++;
+        grouped[key].percent += Number(item['ร้อยละ (%)'] || 0);
+      });
+      Object.entries(grouped).forEach(([group, info]) => {
+        const avg = info.percent / info.count;
+        const card = document.createElement('div');
+        card.className = `p-4 rounded shadow ${avg >= 80 ? 'bg-green-100' : 'bg-red-100'}`;
+        card.innerHTML = `<h3 class="font-semibold">${group}</h3><p>จำนวน KPI: ${info.count}</p><p>เฉลี่ย: ${avg.toFixed(2)}%</p>`;
+        container.appendChild(card);
+      });
+    }
+
+    function renderTable(data) {
+      const tbody = document.getElementById('tableBody');
+      tbody.innerHTML = '';
+      data.forEach(row => {
+        const tr = document.createElement('tr');
+        tr.className = 'odd:bg-white even:bg-gray-50 hover:bg-blue-50 cursor-pointer';
+        tr.innerHTML = `
+          <td class="p-2">${row['ตัวชี้วัดย่อย'] || ''}</td>
+          <td class="p-2">${row['ชื่อหน่วยบริการ'] || ''}</td>
+          <td class="p-2">${row['เป้าหมาย'] || ''}</td>
+          <td class="p-2">${row['ผลงาน'] || ''}</td>
+          <td class="p-2">${row['ร้อยละ (%)'] || ''}</td>
+          <td class="p-2">${row['เกณฑ์ผ่าน (%)'] || ''}</td>
+          <td class="p-2">${row['ข้อมูลวันที่'] || ''}</td>`;
+        tr.addEventListener('click', () => openModal(row));
+        tbody.appendChild(tr);
+      });
+    }
+
+    function openModal(row) {
+      const modal = document.getElementById('modal');
+      const content = document.getElementById('modalContent');
+      content.textContent = JSON.stringify(row, null, 2);
+      modal.classList.remove('hidden');
+    }
+
+    document.getElementById('closeModal').onclick = () => {
+      document.getElementById('modal').classList.add('hidden');
+    };
+
+    fetchAll();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement Google Apps Script endpoints for KPI configuration and data retrieval
- add Tailwind-powered dashboard with filtering, group cards, detail table, and modal
- point frontend to production Apps Script endpoint

## Testing
- `cp Code.gs tmp.js && node --check tmp.js && rm tmp.js` (syntax ok)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1490e3c83218818b996a603fb81