### PR TITLE
Fix syntax error in loadData by wrapping logic in try-catch

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -25,19 +25,13 @@ class KPIDashboard {
   }
 
   async loadData() {
-    const url = "https://script.google.com/macros/s/AKfycbwTCVRGkFte39699yAHm5d1suYsU9RUFM8mjtoohhj5uBWfHKsRkSI3MVbRJyw4oU_YKQ/exec"
-    const response = await axios.get(url)
-    const result = response.data
-    if (result.status !== "success") {
-      throw new Error("API response error")
-    }
-
-    this.data = {
-      timestamp: result.timestamp,
-      configuration: result.data.configuration || [],
-      sourceData: result.data.sourceData || {},
-    }
-
+    try {
+      const url = "https://script.google.com/macros/s/AKfycbwTCVRGkFte39699yAHm5d1suYsU9RUFM8mjtoohhj5uBWfHKsRkSI3MVbRJyw4oU_YKQ/exec"
+      const response = await axios.get(url)
+      const result = response.data
+      if (result.status !== "success") {
+        throw new Error("API response error")
+      }
 
       this.data = {
         timestamp: result.timestamp,


### PR DESCRIPTION
## Summary
- Wrap the `loadData` method in a `try/catch` block and remove duplicate code that caused malformed structure
- Preserve API response handling and filter initialization in the refactored function

## Testing
- `node --check dashboard.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fa8f6c088321a3cc6ad175cdcb23