### PR TITLE
Ensure CORS header and switch to fetch

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -14,43 +14,42 @@ const google = {
 
 function doGet(e) {
   const action = e.parameter.action || "getAllKPIData"
+  let result
 
   try {
     switch (action) {
       case "getKPIConfiguration":
-        return ContentService.createTextOutput(JSON.stringify(getKPIConfiguration())).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getKPIConfiguration()
+        break
 
       case "getSourceSheetData":
         const sheetName = e.parameter.sheetName
-        return ContentService.createTextOutput(JSON.stringify(getSourceSheetData(sheetName))).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getSourceSheetData(sheetName)
+        break
 
       case "getAllKPIData":
-        return ContentService.createTextOutput(JSON.stringify(getAllKPIData())).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getAllKPIData()
+        break
 
       case "getKPIByGroup":
         const groupName = e.parameter.groupName
-        return ContentService.createTextOutput(JSON.stringify(getKPIByGroup(groupName))).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getKPIByGroup(groupName)
+        break
 
       default:
         throw new Error("Invalid action parameter")
     }
   } catch (error) {
-    return ContentService.createTextOutput(
-      JSON.stringify({
-        status: "error",
-        message: error.toString(),
-        timestamp: new Date().toISOString(),
-      }),
-    ).setMimeType(ContentService.MimeType.JSON)
+    result = {
+      status: "error",
+      message: error.toString(),
+      timestamp: new Date().toISOString(),
+    }
   }
+
+  return ContentService.createTextOutput(JSON.stringify(result))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader("Access-Control-Allow-Origin", "*")
 }
 
 function getKPIConfiguration() {

--- a/dashboard.js
+++ b/dashboard.js
@@ -27,8 +27,12 @@ class KPIDashboard {
   async loadData() {
     try {
       const url = "https://script.google.com/macros/s/AKfycbwTCVRGkFte39699yAHm5d1suYsU9RUFM8mjtoohhj5uBWfHKsRkSI3MVbRJyw4oU_YKQ/exec"
-      const response = await axios.get(url)
-      const result = response.data
+      const res = await fetch(url)
+      if (!res.ok) {
+        throw new Error(`HTTP error! status: ${res.status}`)
+      }
+
+      const result = await res.json()
       if (result.status !== "success") {
         throw new Error("API response error")
       }


### PR DESCRIPTION
## Summary
- Always attach `Access-Control-Allow-Origin` in Apps Script `doGet`
- Replace Axios with `fetch` for loading KPI data on the dashboard

## Testing
- `node --check tmp_Code.js`
- `node --check dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6fc7678a08321b2e922e9e5f5a7bb