### PR TITLE
Ensure CORS header and switch to fetch

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,56 +1,46 @@
 // Google Apps Script Backend Code
 // Deploy this as a web app with execute permissions set to "Anyone"
 
-const ContentService = google.script.content
-const SpreadsheetApp = google.script.spreadsheet
-const CacheService = google.script.cache
-const google = {
-  script: {
-    content: ContentService,
-    spreadsheet: SpreadsheetApp,
-    cache: CacheService,
-  },
-}
-
 function doGet(e) {
   const action = e.parameter.action || "getAllKPIData"
+  let result
 
   try {
     switch (action) {
       case "getKPIConfiguration":
-        return ContentService.createTextOutput(JSON.stringify(getKPIConfiguration())).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getKPIConfiguration()
+        break
 
       case "getSourceSheetData":
         const sheetName = e.parameter.sheetName
-        return ContentService.createTextOutput(JSON.stringify(getSourceSheetData(sheetName))).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getSourceSheetData(sheetName)
+        break
 
       case "getAllKPIData":
-        return ContentService.createTextOutput(JSON.stringify(getAllKPIData())).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getAllKPIData()
+        break
 
       case "getKPIByGroup":
         const groupName = e.parameter.groupName
-        return ContentService.createTextOutput(JSON.stringify(getKPIByGroup(groupName))).setMimeType(
-          ContentService.MimeType.JSON,
-        )
+        result = getKPIByGroup(groupName)
+        break
 
       default:
         throw new Error("Invalid action parameter")
     }
   } catch (error) {
-    return ContentService.createTextOutput(
-      JSON.stringify({
-        status: "error",
-        message: error.toString(),
-        timestamp: new Date().toISOString(),
-      }),
-    ).setMimeType(ContentService.MimeType.JSON)
+    result = {
+      status: "error",
+      message: error.toString(),
+      timestamp: new Date().toISOString(),
+    }
   }
+
+  return ContentService.createTextOutput(JSON.stringify(result))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader("Access-Control-Allow-Origin", "*")
+    .setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+    .setHeader("Access-Control-Allow-Headers", "Content-Type")
 }
 
 function getKPIConfiguration() {

--- a/dashboard.js
+++ b/dashboard.js
@@ -27,8 +27,12 @@ class KPIDashboard {
   async loadData() {
     try {
       const url = "https://script.google.com/macros/s/AKfycbwTCVRGkFte39699yAHm5d1suYsU9RUFM8mjtoohhj5uBWfHKsRkSI3MVbRJyw4oU_YKQ/exec"
-      const response = await axios.get(url)
-      const result = response.data
+      const res = await fetch(url, { method: "GET", mode: "cors" })
+      if (!res.ok) {
+        throw new Error(`HTTP error! status: ${res.status}`)
+      }
+
+      const result = await res.json()
       if (result.status !== "success") {
         throw new Error("API response error")
       }

--- a/index.html
+++ b/index.html
@@ -182,7 +182,6 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="dashboard.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add explicit CORS headers for methods and allowed headers in Apps Script
- Fetch KPI data with `mode: "cors"` and drop unused Axios script

## Testing
- `node --check tmp_Code.js`
- `node --check dashboard.js`
- `npx --yes prettier@3.1.0 --check Code.gs dashboard.js index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fc7678a08321b2e922e9e5f5a7bb