### PR TITLE
feat: expand source modal to viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
     <!-- Source Data Modal -->
     <div id="sourceModal" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 overflow-y-auto">
         <div class="flex items-center justify-center min-h-screen p-4">
-            <div class="bg-white rounded-lg shadow-xl max-w-6xl w-full max-h-[90vh] overflow-hidden">
+            <div class="bg-white rounded-lg shadow-xl w-[calc(100vw-4rem)] h-[calc(100vh-4rem)] overflow-hidden">
                 <div class="p-6 border-b border-gray-200 flex items-center justify-between">
                     <div>
                         <h3 class="text-lg font-semibold text-gray-900">ข้อมูลต้นฉบับ</h3>
@@ -236,8 +236,8 @@
                         <i data-lucide="x" class="w-6 h-6"></i>
                     </button>
                 </div>
-                
-                <div class="p-6 overflow-auto max-h-[70vh]">
+
+                <div class="p-6 overflow-auto h-[calc(100vh-12rem)]">
                     <div id="sourceDataContent" class="overflow-x-auto">
                         <!-- Source data table will be inserted here -->
                     </div>


### PR DESCRIPTION
## Summary
- expand Source Data modal to nearly full-screen dimensions using `calc(100vw-4rem)` and `calc(100vh-4rem)`
- adjust modal content area height to match new viewport-based sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7226b47488321b1a3631282320616