### PR TITLE
Rename source data section to details and include processing date summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
             <div class="bg-white rounded-lg shadow-xl w-[calc(100vw-4rem)] h-[calc(100vh-4rem)] overflow-hidden">
                 <div class="p-6 border-b border-gray-200 flex items-center justify-between">
                     <div>
-                        <h3 class="text-lg font-semibold text-gray-900">ข้อมูลต้นฉบับ</h3>
+                        <h3 class="text-lg font-semibold text-gray-900">รายละเอียด</h3>
                         <p id="sourceSheetName" class="text-sm text-gray-600"></p>
                     </div>
                     <button id="closeModal" class="text-gray-400 hover:text-gray-600 transition-colors">
@@ -817,7 +817,7 @@
         // Show source data modal
         async function showSourceData(sheetName, serviceCode) {
             if (!sheetName) {
-                alert('ไม่มีข้อมูลต้นฉบับ');
+                alert('ไม่มีรายละเอียด');
                 return;
             }
             
@@ -868,7 +868,7 @@
             }
 
             const allHeaders = Object.keys(data[0]);
-            const summaryFields = ['รหัสหน่วยบริการ','ชื่อหน่วยบริการ','รหัสพื้นที่','วันที่รายงาน','ปีงบประมาณ'];
+            const summaryFields = ['วันที่ประมวลผล','รหัสหน่วยบริการ','ชื่อหน่วยบริการ','รหัสพื้นที่','วันที่รายงาน','ปีงบประมาณ'];
 
             const summaryHtml = summaryFields
                 .filter(field => field in data[0])


### PR DESCRIPTION
## Summary
- Rename "ข้อมูลต้นฉบับ" modal heading and related alert to "รายละเอียด"
- Move processing date into summary fields so it appears at top of details modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c4dfce88321b4dd20bd7f512121