### PR TITLE
feat: update icons and pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <title>KPI Dashboard - ระบบติดตามตัวชี้วัด</title>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    
-    <!-- Lucide Icons -->
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+
+    <!-- Font Awesome Icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     
     <!-- Thai Font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -36,7 +36,7 @@
             <div class="flex flex-col md:flex-row md:items-center md:justify-between">
                 <div class="flex items-center space-x-3 mb-4 md:mb-0">
                     <div class="p-2 bg-blue-500 rounded-lg">
-                        <i data-lucide="bar-chart-3" class="text-white w-6 h-6"></i>
+                        <i class="fa-solid fa-chart-bar text-white w-6 h-6"></i>
                     </div>
                     <div>
                         <h1 class="text-2xl font-bold text-gray-900">KPI Dashboard</h1>
@@ -46,7 +46,7 @@
                 
                 <div class="flex items-center space-x-4">
                     <button id="refreshBtn" class="flex items-center space-x-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors">
-                        <i data-lucide="refresh-cw" class="w-4 h-4"></i>
+                        <i class="fa-solid fa-rotate-right w-4 h-4"></i>
                         <span>รีเฟรช</span>
                     </button>
                 </div>
@@ -67,7 +67,7 @@
         <!-- Error State -->
         <div id="errorState" class="hidden bg-red-50 border border-red-200 rounded-lg p-6 mb-6">
             <div class="flex items-center space-x-3">
-                <i data-lucide="alert-circle" class="text-red-500 w-6 h-6"></i>
+                <i class="fa-solid fa-circle-exclamation text-red-500 w-6 h-6"></i>
                 <div>
                     <h3 class="font-semibold text-red-800">เกิดข้อผิดพลาด</h3>
                     <p id="errorMessage" class="text-red-600"></p>
@@ -89,7 +89,7 @@
                             <p id="totalKPIs" class="text-2xl font-bold text-gray-900">0</p>
                         </div>
                         <div class="p-3 bg-blue-100 rounded-full">
-                            <i data-lucide="target" class="text-blue-600 w-6 h-6"></i>
+                            <i class="fa-solid fa-bullseye text-blue-600 w-6 h-6"></i>
                         </div>
                     </div>
                 </div>
@@ -101,7 +101,7 @@
                             <p id="averagePercentage" class="text-2xl font-bold text-gray-900">0%</p>
                         </div>
                         <div class="p-3 bg-purple-100 rounded-full">
-                            <i data-lucide="percent" class="text-purple-600 w-6 h-6"></i>
+                            <i class="fa-solid fa-percent text-purple-600 w-6 h-6"></i>
                         </div>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                             <p id="passedKPIs" class="text-2xl font-bold text-green-600">0</p>
                         </div>
                         <div class="p-3 bg-green-100 rounded-full">
-                            <i data-lucide="check-circle" class="text-green-600 w-6 h-6"></i>
+                            <i class="fa-solid fa-circle-check text-green-600 w-6 h-6"></i>
                         </div>
                     </div>
                 </div>
@@ -125,7 +125,7 @@
                             <p id="failedKPIs" class="text-2xl font-bold text-red-600">0</p>
                         </div>
                         <div class="p-3 bg-red-100 rounded-full">
-                            <i data-lucide="x-circle" class="text-red-600 w-6 h-6"></i>
+                            <i class="fa-solid fa-circle-xmark text-red-600 w-6 h-6"></i>
                         </div>
                     </div>
                 </div>
@@ -224,13 +224,16 @@
                 <!-- Pagination -->
                 <div id="tablePagination" class="px-6 py-3 border-t border-gray-200 bg-gray-50">
                     <div class="flex items-center justify-between">
-                        <button id="prevPage" class="px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
-                            ก่อนหน้า
-                        </button>
+                        <div class="flex items-center space-x-2">
+                            <button id="prevPage" class="px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
+                                ก่อนหน้า
+                            </button>
+                            <div id="pageNumbers" class="flex space-x-1"></div>
+                            <button id="nextPage" class="px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
+                                ถัดไป
+                            </button>
+                        </div>
                         <span id="pageInfo" class="text-sm text-gray-700">หน้า 1 จาก 1</span>
-                        <button id="nextPage" class="px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
-                            ถัดไป
-                        </button>
                     </div>
                 </div>
             </div>
@@ -247,7 +250,7 @@
                         <p id="sourceSheetName" class="text-sm text-gray-600"></p>
                     </div>
                     <button id="closeModal" class="text-gray-400 hover:text-gray-600 transition-colors">
-                        <i data-lucide="x" class="w-6 h-6"></i>
+                        <i class="fa-solid fa-xmark w-6 h-6"></i>
                     </button>
                 </div>
 
@@ -272,17 +275,9 @@
         
         // Initialize dashboard
         document.addEventListener('DOMContentLoaded', function() {
-            initializeLucideIcons();
             setupEventListeners();
             loadDashboardData();
         });
-
-        // Initialize Lucide icons
-        function initializeLucideIcons() {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        }
 
         // Setup event listeners
         function setupEventListeners() {
@@ -406,8 +401,6 @@
             updateTable();
             updateSelectedTags();
 
-            // Initialize Lucide icons for newly created elements
-            initializeLucideIcons();
         }
 
         // Update summary statistics
@@ -607,7 +600,7 @@
                     <div class="flex items-center justify-between mb-4">
                         <h3 class="font-semibold text-gray-900 text-lg">${groupName}</h3>
                         <div class="p-2 bg-blue-100 rounded-full">
-                            <i data-lucide="folder" class="text-blue-600 w-5 h-5"></i>
+                            <i class="fa-solid fa-folder text-blue-600 w-5 h-5"></i>
                         </div>
                     </div>
                     
@@ -728,7 +721,6 @@
             createGroupCards(filteredData);
             updateSummaryStats(filteredData);
             updateTable();
-            initializeLucideIcons();
             updateSelectedTags();
         }
 
@@ -799,7 +791,7 @@
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap">
                     <button class="text-blue-600 hover:text-blue-800" onclick="showSourceData('${item.sheet_source}', '${item.service_code_ref}')" aria-label="ดูข้อมูล">
-                        <i data-lucide="external-link" class="w-4 h-4"></i>
+                        <i class="fa-solid fa-arrow-up-right-from-square w-4 h-4"></i>
                     </button>
                 </td>
             `;
@@ -861,7 +853,7 @@
             }
 
             const allHeaders = Object.keys(data[0]);
-            const summaryFields = ['วันที่ประมวลผล','รหัสหน่วยบริการ','ชื่อหน่วยบริการ','วันที่รายงาน','ปีงบประมาณ','รหัสพื้นที่'];
+            const summaryFields = ['วันที่ประมวลผล','รหัสหน่วยบริการ','ชื่อหน่วยบริการ','วันที่รายงาน','ปีงบประมาณ'];
 
             const summaryHtml = summaryFields
                 .filter(field => field in data[0])
@@ -917,10 +909,23 @@
             const prevBtn = document.getElementById('prevPage');
             const nextBtn = document.getElementById('nextPage');
             const pageInfo = document.getElementById('pageInfo');
-            
+            const pageNumbers = document.getElementById('pageNumbers');
+
             prevBtn.disabled = currentPage <= 1;
             nextBtn.disabled = currentPage >= totalPages;
             pageInfo.textContent = `หน้า ${currentPage} จาก ${totalPages}`;
+
+            pageNumbers.innerHTML = '';
+            for (let i = 1; i <= totalPages; i++) {
+                const btn = document.createElement('button');
+                btn.textContent = i;
+                btn.className = `px-3 py-1 rounded ${i === currentPage ? 'bg-blue-500 text-white' : 'bg-white border border-gray-300 hover:bg-gray-50'}`;
+                btn.addEventListener('click', () => {
+                    currentPage = i;
+                    updateTable();
+                });
+                pageNumbers.appendChild(btn);
+            }
         }
 
         // Change page


### PR DESCRIPTION
## Summary
- switch to Tailwind browser CDN and replace Lucide with Font Awesome icons
- show area code inside KPI detail tables
- add numbered pagination controls for KPI detail
- correct Font Awesome CDN integrity and remove unused icon initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f985e7c832196d4564da777c1d4